### PR TITLE
Fix SaveState slot usage and cleanup resources

### DIFF
--- a/Src/Emulator.cpp
+++ b/Src/Emulator.cpp
@@ -201,6 +201,20 @@ void Emulator::Free() {
     glBindTexture(GL_TEXTURE_2D, 0);
     glDeleteTextures(1, &screenTextureId);
     glDeleteTextures(1, &stateImageId);
+
+    if (currentGame != nullptr) {
+        for (int i = 0; i < 10; ++i) {
+            delete[] currentGame->saveStates[i].saveImage;
+            currentGame->saveStates[i].saveImage = nullptr;
+        }
+        delete currentGame;
+        currentGame = nullptr;
+    }
+
+    delete[] pixelData;
+    pixelData = nullptr;
+    delete[] stateImageData;
+    stateImageData = nullptr;
 }
 
 void Emulator::Init(std::string appFolderPath, LayerBuilder *_layerBuilder, DrawHelper *_drawHelper, OpenSLWrapper *openSLWrap) {
@@ -659,7 +673,7 @@ void Emulator::SaveState(int slot) {
 
     if (size > 0) {
         std::string savePath = stateFolderPath + CurrentRom->RomName + ".state";
-        if (ovrVirtualBoyGo::global.saveSlot > 0) savePath += ToString(ovrVirtualBoyGo::global.saveSlot);
+        if (slot > 0) savePath += ToString(slot);
 
         OVR_LOG("save slot");
         void *data = new uint8_t[size];
@@ -673,14 +687,14 @@ void Emulator::SaveState(int slot) {
     }
 
     OVR_LOG("copy image");
-    memcpy(currentGame->saveStates[ovrVirtualBoyGo::global.saveSlot].saveImage, screenData,
+    memcpy(currentGame->saveStates[slot].saveImage, screenData,
            sizeof(uint8_t) * VIDEO_WIDTH * VIDEO_HEIGHT);
     OVR_LOG("update image");
-    UpdateStateImage(ovrVirtualBoyGo::global.saveSlot);
+    UpdateStateImage(slot);
     // save image for the slot
-    SaveStateImage(ovrVirtualBoyGo::global.saveSlot);
-    currentGame->saveStates[ovrVirtualBoyGo::global.saveSlot].hasImage = true;
-    currentGame->saveStates[ovrVirtualBoyGo::global.saveSlot].hasState = true;
+    SaveStateImage(slot);
+    currentGame->saveStates[slot].hasImage = true;
+    currentGame->saveStates[slot].hasState = true;
 }
 
 void Emulator::LoadState(int slot) {


### PR DESCRIPTION
## Summary
- fix SaveState to respect the provided slot argument
- free allocated frame/state buffers during shutdown

## Testing
- `./Projects/Android/gradlew -q tasks` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*
- `python Projects/Android/build.py` *(fails: Unable to find SDK root)*

------
https://chatgpt.com/codex/tasks/task_e_68525966e6d08325b246c5b92990fed3